### PR TITLE
Fix overwriting of forecast horizon and max sample size of 5000

### DIFF
--- a/R/lassovar-internal.R
+++ b/R/lassovar-internal.R
@@ -176,7 +176,7 @@ return(lasso.ic)
 		names(sptest) <- c('Ljung-Box','Shapiro','R2')		
 	} else {
 		sptest <- c(BP,R2)
-		names(sptest) <- c('Ljung-Box,'R2')
+		names(sptest) <- c('Ljung-Box','R2')
 	}
 	
 	return(sptest)

--- a/R/lassovar-internal.R
+++ b/R/lassovar-internal.R
@@ -168,12 +168,16 @@ return(lasso.ic)
 	
 
 	BP <- Box.test(mres,lag=lags,type="Ljung-Box",fitdf=floor(fitdf))$p.val
-	SW <- shapiro.test(mres)$p.value
+	SW <- try(shapiro.test(mres)$p.value, silent = TRUE) # handles the case of supplying a sample size larger than 5,000 (otherwise error message from shapiro.test() function)
 	R2 <- 1-((length(mres)*var(mres,na.rm=TRUE))/(var(yi)*length(yi)))
 
-	sptest <- c(BP,SW,R2)
-	names(sptest) <- c('Ljung-Box','Shapiro','R2')		
-	
+	if(SW) {
+		sptest <- c(BP,SW,R2)
+		names(sptest) <- c('Ljung-Box','Shapiro','R2')		
+	} else {
+		sptest <- c(BP,R2)
+		names(sptest) <- c('Ljung-Box,'R2')
+	}
 	
 	return(sptest)
 	}

--- a/R/lassovar-internal.R
+++ b/R/lassovar-internal.R
@@ -6,15 +6,15 @@
 
 # The workhorse, fits a lasso possibly adaptive given weights ada.w and selects the best model according both information criteria. 
 .lassovar.eq <-
-function(y,x,ada.w,degf.type=NULL,ic,mc=FALSE,ncores=1,alpha=1,dfmax,trend)
+function(y,x,ada.w,degf.type=NULL,ic,mc=FALSE,ncores=1,alpha=1,dfmax,trend,lambda=NULL)
 {
 	lasso.eq	<-list('call'=match.call(),'var.names'=colnames(y),'ada.w'=ada.w,'x'=x,'y'=y,'coefficients'=NULL,'RSS'=NULL,'lambda'=NULL,'spectest'=NULL,'trend'=trend)	
 	all.ic		<-list()
 
 	
 	#Estimation with and w/o multicore
-	if(!mc){for(i in 1:ncol(y)){ all.ic[[i]]	<-.lv.eq.gn(i,y,x,ada.w,ic=ic,alpha=alpha,dfmax=dfmax,trend)}}
-	if(mc){	all.ic<-mclapply(1:ncol(y),.lv.eq.gn,y,x,ada.w,ic=ic,alpha=alpha,dfmax=dfmax,trend,mc.cores=ncores)}
+	if(!mc){for(i in 1:ncol(y)){ all.ic[[i]]	<-.lv.eq.gn(i,y,x,ada.w,ic=ic,alpha=alpha,dfmax=dfmax,trend,lambda=lambda)}}
+	if(mc){	all.ic<-mclapply(1:ncol(y),.lv.eq.gn,y,x,ada.w,ic=ic,alpha=alpha,dfmax=dfmax,trend,mc.cores=ncores,lambda=lambda)}
 
 
 	#Sorting out the IC results
@@ -40,9 +40,8 @@ return(lasso.eq)
 
 
 # Core function. Estimation of the Lasso and model selection.
-.lv.eq.gn<-function(i,y,x,ada.w,ic,alpha,dfmax,trend)
+.lv.eq.gn<-function(i,y,x,ada.w,ic,alpha,dfmax,trend,lambda = NULL)
 {
-
 	
 # Computing exclusion vectors.	
 	all.excl<-NULL
@@ -51,7 +50,7 @@ return(lasso.eq)
 	if(is.null(ada.w)){
 		wpen <- rep(1,ncol(x))
 		if(trend)wpen[ncol(x)] <- 0 # no penalty for the trend
-		gn.mod	<-glmnet(x=x,y=y[,i],family='gaussian',exclude=all.excl,penalty.factor=wpen,alpha=alpha,dfmax=dfmax,standardize=TRUE,type.gaussian='covariance')}
+		gn.mod	<-glmnet(x=x,y=y[,i],family='gaussian',exclude=all.excl,penalty.factor=wpen,alpha=alpha,dfmax=dfmax,standardize=TRUE,type.gaussian='covariance',lambda=lambda)}
 	
 	# In case of adaptive lasso
 	if(!is.null(ada.w)){
@@ -65,7 +64,7 @@ return(lasso.eq)
 			wpen[which(wpen==Inf)]<-0 # variables with Inf weights are manually removed. 
 			if(trend)wpen[ncol(x)] <- 0 # no penalty for the trend
 			
-			gn.mod	<-glmnet(x=x,y=y[,i],family='gaussian',exclude=c(all.excl,which(ada.w$w[,i]==Inf)),penalty.factor=wpen,alpha=alpha,dfmax=dfmax,standardize=FALSE,type.gaussian='covariance')}
+			gn.mod	<-glmnet(x=x,y=y[,i],family='gaussian',exclude=c(all.excl,which(ada.w$w[,i]==Inf)),penalty.factor=wpen,alpha=alpha,dfmax=dfmax,standardize=FALSE,type.gaussian='covariance',lambda=lambda)}
 	}
   
 	if(!is.null(gn.mod)){lv.ic		<-.ic.modsel(gn.mod,yi=y[,i],x=x,ic=ic,alpha=alpha)}

--- a/R/lassovar-internal.R
+++ b/R/lassovar-internal.R
@@ -171,7 +171,7 @@ return(lasso.ic)
 	SW <- try(shapiro.test(mres)$p.value, silent = TRUE) # handles the case of supplying a sample size larger than 5,000 (otherwise error message from shapiro.test() function)
 	R2 <- 1-((length(mres)*var(mres,na.rm=TRUE))/(var(yi)*length(yi)))
 
-	if(SW) {
+	if(is.numeric(SW)==T) {
 		sptest <- c(BP,SW,R2)
 		names(sptest) <- c('Ljung-Box','Shapiro','R2')		
 	} else {

--- a/R/lassovar.R
+++ b/R/lassovar.R
@@ -40,7 +40,7 @@
 #' }
 #'
 #' @export
-lassovar<-function(dat,exo=NULL,lags=1,ic=c('BIC','AIC'),adaptive=c('none','ols','lasso','group','ridge'),post=FALSE,mc=FALSE,ncores=NULL,dfmax=NULL,horizon=1,trend=FALSE)
+lassovar<-function(dat,exo=NULL,lags=1,ic=c('BIC','AIC'),adaptive=c('none','ols','lasso','group','ridge'),post=FALSE,mc=FALSE,ncores=NULL,dfmax=NULL,horizon=1,trend=FALSE,lambda=NULL)
 {
 	
 	# matching the multiple choice arguments. 
@@ -78,7 +78,7 @@ lassovar<-function(dat,exo=NULL,lags=1,ic=c('BIC','AIC'),adaptive=c('none','ols'
 	else ada.w<-NULL
 	
 	#cat('Estimating the Final Lasso: ','\n',sep='')
-	las.mod<-.lassovar.eq(y.var$y,y.var$x,ada.w,ic=ic,mc=mc,ncores=ncores,dfmax=dfmax,trend=trend)
+	las.mod<-.lassovar.eq(y.var$y,y.var$x,ada.w,ic=ic,mc=mc,ncores=ncores,dfmax=dfmax,trend=trend,lambda=lambda)
 
 
 	if(post){	las.mod$post <- .post.ols(y.var$y,y.var$x,sel.pars=las.mod$coefficients!=0,mc=mc,ncores=ncores)}		

--- a/R/lassovar.R
+++ b/R/lassovar.R
@@ -64,7 +64,7 @@ lassovar<-function(dat,exo=NULL,lags=1,ic=c('BIC','AIC'),adaptive=c('none','ols'
 	# maxdegrees of freedom ?	
 	if(!is.null(dfmax))dfmax<-as.integer(dfmax)	else dfmax	<-ncol(dat)*lags
 
-	y.var	<-.mkvar(dat,lags=lags,horizon=1,exo=exo,trend=trend)	
+	y.var	<-.mkvar(dat,lags=lags,horizon=horizon,exo=exo,trend=trend)	
 	
 	if(adaptive!='none'){
 		cat('initial estimator for the adapive lasso: ',adaptive,'\n',sep='')

--- a/R/lassovar.R
+++ b/R/lassovar.R
@@ -14,6 +14,7 @@
 #' @param post Optional, Should a post Lasso OLS be estimated, default FALSE.
 #' @param horizon Estimate a h-step ahead VAR, useful for direct forecasting. Default = 1.
 #' @param trend Should a linear trend be included in the model. 
+#' @param lambda Running a penalized VAR model. Setting = 0 leads to a regular VAR estimation.
 #'
 #' @return 
 #' A list with S3 class \pkg{lassovar}.

--- a/R/lassovar.R
+++ b/R/lassovar.R
@@ -14,7 +14,7 @@
 #' @param post Optional, Should a post Lasso OLS be estimated, default FALSE.
 #' @param horizon Estimate a h-step ahead VAR, useful for direct forecasting. Default = 1.
 #' @param trend Should a linear trend be included in the model. 
-#' @param lambda Running a penalized VAR model. Setting = 0 leads to a regular VAR estimation.
+#' @param lambda Passing user-defind lambda value(s). Setting = 0 leads to a regular VAR estimation.
 #'
 #' @return 
 #' A list with S3 class \pkg{lassovar}.


### PR DESCRIPTION
The forecast horizon passed as an argument in the lassovar() function has been overwritten with the value 1. Additionally, the shapiro.test() function inside the .lassovar.eq() function restricts the sample size of the inputs to a maximum of 5,000. An easy fix is proposed below (simply ignoring the shapiro.test if the input data has more than 5,000 observations). 

For my own workflow, I added the option to pass user-defined lambda values or predict a regular VAR by setting the lambda to 0.